### PR TITLE
feat(commit-flow): add option to switch between manual and ai commit …

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import typescript from "@rollup/plugin-typescript";
 
-const external = ["node:fs", "node:path", "node:child_process", "node:util", "@commitlint/load", "@commitlint/types", "chalk", "dotenv", "lodash.isplainobject", "@anthropic-ai/sdk", "openai"];
+const external = ["node:fs", "node:path", "node:child_process", "node:util", "@commitlint/load", "@commitlint/types", "chalk", "dotenv", "lodash.isplainobject", "@anthropic-ai/sdk", "openai", "inquirer"];
 
 export default [
 	{

--- a/src/services/llm/index.ts
+++ b/src/services/llm/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @elsikora-typescript/no-unsafe-assignment,@elsikora-typescript/no-unsafe-call,@elsikora-typescript/no-unsafe-member-access,@elsikora-typescript/restrict-template-expressions */
-import type { CommitConfig, LLMConfig, LLMConfigStorage, LLMPromptContext, LLMProvider } from "./types.js";
+import type { CommitConfig, LLMConfig, LLMConfigStorage, LLMPromptContext } from "./types.js";
 
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
@@ -85,7 +85,10 @@ export async function selectLLMProvider(inquirer: any): Promise<void> {
 	let model: string;
 	let mode: string = "auto"; // Default mode
 
-	if (existingConfig) {
+	const isProviderExist: boolean = Boolean(existingConfig?.provider);
+	const isModelExist: boolean = Boolean(existingConfig?.model) && existingConfig?.model !== "undefined";
+
+	if (existingConfig && isProviderExist && isModelExist) {
 		// We have a saved config
 		provider = existingConfig.provider;
 		model = existingConfig.model;
@@ -194,11 +197,11 @@ export async function selectLLMProvider(inquirer: any): Promise<void> {
 			// In manual mode, we don't need a model or provider, so skip forward
 			if (mode === "manual") {
 				// Even in manual mode, save the config to remember the mode choice
+				// eslint-disable-next-line @elsikora/typescript/no-non-null-assertion
+				const oldConfig: LLMConfig = getLLMConfig()!;
 				setLLMConfig({
-					apiKey: "",
+					...oldConfig,
 					mode: "manual",
-					model: model || "",
-					provider: (provider as LLMProvider) || "",
 				});
 
 				console.log(chalk.green(`✅ Manual commit mode configured successfully!`));
@@ -276,10 +279,10 @@ export async function selectLLMProvider(inquirer: any): Promise<void> {
 	const modeResponse: any = await inquirer.prompt([
 		{
 			choices: [
-				{ name: "AI-powered (auto)", value: "auto" },
 				{ name: "Manual (traditional commitizen)", value: "manual" },
+				{ name: "AI-powered (auto)", value: "auto" },
 			],
-			default: "auto",
+			default: "manual",
 			message: "Select your preferred commit mode:",
 			name: "mode",
 			type: "list",
@@ -292,12 +295,12 @@ export async function selectLLMProvider(inquirer: any): Promise<void> {
 	if (mode === "manual") {
 		// Save minimal config with just the mode
 		// Note: explicit provider/model values to make debugging easier
+
+		// eslint-disable-next-line @elsikora/typescript/no-non-null-assertion
+		const oldConfig: LLMConfig = getLLMConfig()!;
 		setLLMConfig({
-			apiKey: "",
+			...oldConfig,
 			mode: "manual",
-			model: "none",
-			// @ts-ignore
-			provider: "none",
 		});
 
 		console.log(chalk.green(`✅ Manual commit mode configured successfully!`));


### PR DESCRIPTION
…modes

This update enhances the commit flow by adding a prompt that allows users to switch between manual and AI-powered commit modes during the commit process. Previously, the mode was fixed at configuration time, but now users can toggle between modes on demand.

Additional changes include:
- Adding inquirer to external dependencies in rollup config
- Improving configuration persistence to maintain existing settings when changing modes
- Setting manual mode as the default option in the configuration menu.