### PR TITLE
fix(ci): type status reporter mock

### DIFF
--- a/test/unit/application/use-case/validate-commit-message.use-case.test.ts
+++ b/test/unit/application/use-case/validate-commit-message.use-case.test.ts
@@ -1,3 +1,5 @@
+import type { Mock } from "vitest";
+
 import type { ICommitValidationResult, ICommitValidator } from "@application/interface/commit-validator.interface";
 import type { CommitMessage } from "@domain/entity/commit-message.entity";
 
@@ -11,7 +13,7 @@ describe("ValidateCommitMessageUseCase", () => {
 	let useCase: ValidateCommitMessageUseCase;
 	let mockValidator: ICommitValidator;
 	let mockCommitMessage: CommitMessage;
-	let statusReporter: ReturnType<typeof vi.fn>;
+	let statusReporter: Mock<(message: string) => void>;
 
 	beforeEach(() => {
 		// Mock validator
@@ -19,7 +21,7 @@ describe("ValidateCommitMessageUseCase", () => {
 			validate: vi.fn(),
 			fix: vi.fn(),
 		};
-		statusReporter = vi.fn();
+		statusReporter = vi.fn<(message: string) => void>();
 
 		// Create use case
 		useCase = new ValidateCommitMessageUseCase(mockValidator, 3, statusReporter);

--- a/test/unit/infrastructure/llm/ai-core-llm.service.test.ts
+++ b/test/unit/infrastructure/llm/ai-core-llm.service.test.ts
@@ -49,5 +49,4 @@ describe("AiCoreLlmService", () => {
 		expect(generate.mock.calls[0]?.[0]).not.toHaveProperty("retries");
 		expect(generate.mock.calls[0]?.[0]).not.toHaveProperty("temperature");
 	});
-
 });


### PR DESCRIPTION
## Summary
- Type the Vitest `statusReporter` mock as `(message: string) => void` so `tsc --noEmit` accepts it in CI.

## Test plan
- `npm run lint:types`
- `npm run lint:all`
- `npm run test:unit`